### PR TITLE
rename DistributionKind to ProjectKind

### DIFF
--- a/lib/constructs/source-repo.ts
+++ b/lib/constructs/source-repo.ts
@@ -5,20 +5,20 @@ import { Code, Repository } from 'aws-cdk-lib/aws-codecommit';
 import * as path from 'path';
 
 /**
- * The kind of Yocto Distribution built.
+ * The kind of project built.
  */
-export enum DistributionKind {
-  /** A Poky Based Distribution. */
+export enum ProjectKind {
+  /** Build core-image-minimal from poky. */
   Poky = 'poky',
-  /** The meta-aws Demonstration Distribution. */
+  /** Build the Qemu meta-aws Demonstration Distribution. */
   MetaAwsDemo = 'meta-aws-demo',
 }
 
 export interface SourceRepoProps extends cdk.StackProps {
   /** The name of the CodeCommit Repository created. */
   readonly repoName: string;
-  /** The type of distribution to see this repository with. */
-  readonly kind: DistributionKind;
+  /** The type of project to seed this repository with. */
+  readonly kind: ProjectKind;
 }
 
 /**

--- a/lib/demo-pipeline.ts
+++ b/lib/demo-pipeline.ts
@@ -25,7 +25,7 @@ import {
   SecurityGroup,
 } from 'aws-cdk-lib/aws-ec2';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
-import { SourceRepo, DistributionKind } from './constructs/source-repo';
+import { SourceRepo, ProjectKind } from './constructs/source-repo';
 
 /**
  * Properties to allow customizing the build.
@@ -38,7 +38,7 @@ export interface DemoPipelineProps extends cdk.StackProps {
   /** VPC where the networking setup resides. */
   readonly vpc: IVpc;
   /** The type of Layer  */
-  readonly distroKind?: DistributionKind;
+  readonly distroKind?: ProjectKind;
   /** A name for the layer-repo that is created. Default is 'layer-repo' */
   readonly layerRepoName?: string;
 }
@@ -71,7 +71,7 @@ export class DemoPipelineStack extends cdk.Stack {
     const sourceRepo = new SourceRepo(this, 'SourceRepo', {
       ...props,
       repoName: props.layerRepoName ?? `layer-repo-${this.stackName}`,
-      kind: props.distroKind ?? DistributionKind.Poky,
+      kind: props.distroKind ?? ProjectKind.Poky,
     });
 
     const sourceOutput = new codepipeline.Artifact();

--- a/test/source-repo.test.ts
+++ b/test/source-repo.test.ts
@@ -1,11 +1,11 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { SourceRepo, DistributionKind } from '../lib/constructs/source-repo';
+import { SourceRepo, ProjectKind } from '../lib/constructs/source-repo';
 
 describe('Demo Source Repository', () => {
   const props = {
     env: { account: '12341234', region: 'eu-central-1' },
-    kind: DistributionKind.Poky,
+    kind: ProjectKind.Poky,
     repoName: 'charlie',
   };
 


### PR DESCRIPTION
This more accurately reflects what is being created. The starting projects do not just use a specific distro, but build a specific target with specific config options.