### PR TITLE
Setup access logging in Pipeline Artifact Buckets

### DIFF
--- a/test/__snapshots__/build-image-pipeline.test.ts.snap
+++ b/test/__snapshots__/build-image-pipeline.test.ts.snap
@@ -10,6 +10,71 @@ exports[`Build Image Pipeline Snapshot 1`] = `
     },
   },
   "Resources": {
+    "ArtifactAccessLoggingD6FCABA3": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter",
+            },
+          ],
+        },
+        "VersioningConfiguration": {
+          "Status": "Enabled",
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ArtifactAccessLoggingPolicyDC97CE59": {
+      "Properties": {
+        "Bucket": {
+          "Ref": "ArtifactAccessLoggingD6FCABA3",
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*",
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "ArtifactAccessLoggingD6FCABA3",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "ArtifactAccessLoggingD6FCABA3",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "BuildImageBuildLogs65D4471D": {
       "DeletionPolicy": "Retain",
       "Properties": {
@@ -28,14 +93,14 @@ exports[`Build Image Pipeline Snapshot 1`] = `
           "EncryptionKey": {
             "Id": {
               "Fn::GetAtt": [
-                "BuildImagePipelineArtifactsBucketEncryptionKey5E194B47",
+                "PipelineArtifactKeyEC0C0075",
                 "Arn",
               ],
             },
             "Type": "KMS",
           },
           "Location": {
-            "Ref": "BuildImagePipelineArtifactsBucketC6CC33E0",
+            "Ref": "PipelineArtifacts4A9B2621",
           },
           "Type": "S3",
         },
@@ -114,126 +179,6 @@ exports[`Build Image Pipeline Snapshot 1`] = `
         ],
       },
       "Type": "AWS::CodePipeline::Pipeline",
-    },
-    "BuildImagePipelineArtifactsBucketC6CC33E0": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "BucketEncryption": {
-          "ServerSideEncryptionConfiguration": [
-            {
-              "ServerSideEncryptionByDefault": {
-                "KMSMasterKeyID": {
-                  "Fn::GetAtt": [
-                    "BuildImagePipelineArtifactsBucketEncryptionKey5E194B47",
-                    "Arn",
-                  ],
-                },
-                "SSEAlgorithm": "aws:kms",
-              },
-            },
-          ],
-        },
-        "PublicAccessBlockConfiguration": {
-          "BlockPublicAcls": true,
-          "BlockPublicPolicy": true,
-          "IgnorePublicAcls": true,
-          "RestrictPublicBuckets": true,
-        },
-      },
-      "Type": "AWS::S3::Bucket",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "BuildImagePipelineArtifactsBucketEncryptionKey5E194B47": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "KeyPolicy": {
-          "Statement": [
-            {
-              "Action": "kms:*",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::111111111111:root",
-                    ],
-                  ],
-                },
-              },
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::KMS::Key",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "BuildImagePipelineArtifactsBucketEncryptionKeyAlias74B7C629": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "AliasName": "alias/codepipeline-repostackmyteststackbuildimagepipelineec25138e",
-        "TargetKeyId": {
-          "Fn::GetAtt": [
-            "BuildImagePipelineArtifactsBucketEncryptionKey5E194B47",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::KMS::Alias",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "BuildImagePipelineArtifactsBucketPolicyA1FD352D": {
-      "Properties": {
-        "Bucket": {
-          "Ref": "BuildImagePipelineArtifactsBucketC6CC33E0",
-        },
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "s3:*",
-              "Condition": {
-                "Bool": {
-                  "aws:SecureTransport": "false",
-                },
-              },
-              "Effect": "Deny",
-              "Principal": {
-                "AWS": "*",
-              },
-              "Resource": [
-                {
-                  "Fn::GetAtt": [
-                    "BuildImagePipelineArtifactsBucketC6CC33E0",
-                    "Arn",
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "BuildImagePipelineArtifactsBucketC6CC33E0",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::S3::BucketPolicy",
     },
     "BuildImagePipelineBuildCodePipelineActionRole15E18A3A": {
       "Properties": {
@@ -383,7 +328,7 @@ exports[`Build Image Pipeline Snapshot 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "BuildImagePipelineArtifactsBucketC6CC33E0",
+                    "PipelineArtifacts4A9B2621",
                     "Arn",
                   ],
                 },
@@ -393,7 +338,7 @@ exports[`Build Image Pipeline Snapshot 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "BuildImagePipelineArtifactsBucketC6CC33E0",
+                          "PipelineArtifacts4A9B2621",
                           "Arn",
                         ],
                       },
@@ -414,7 +359,7 @@ exports[`Build Image Pipeline Snapshot 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "BuildImagePipelineArtifactsBucketEncryptionKey5E194B47",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -521,7 +466,7 @@ exports[`Build Image Pipeline Snapshot 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "BuildImagePipelineArtifactsBucketC6CC33E0",
+                    "PipelineArtifacts4A9B2621",
                     "Arn",
                   ],
                 },
@@ -531,7 +476,7 @@ exports[`Build Image Pipeline Snapshot 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "BuildImagePipelineArtifactsBucketC6CC33E0",
+                          "PipelineArtifacts4A9B2621",
                           "Arn",
                         ],
                       },
@@ -551,7 +496,7 @@ exports[`Build Image Pipeline Snapshot 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "BuildImagePipelineArtifactsBucketEncryptionKey5E194B47",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -578,7 +523,7 @@ exports[`Build Image Pipeline Snapshot 1`] = `
         },
         "EncryptionKey": {
           "Fn::GetAtt": [
-            "BuildImagePipelineArtifactsBucketEncryptionKey5E194B47",
+            "PipelineArtifactKeyEC0C0075",
             "Arn",
           ],
         },
@@ -804,7 +749,7 @@ exports[`Build Image Pipeline Snapshot 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "BuildImagePipelineArtifactsBucketC6CC33E0",
+                    "PipelineArtifacts4A9B2621",
                     "Arn",
                   ],
                 },
@@ -814,7 +759,7 @@ exports[`Build Image Pipeline Snapshot 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "BuildImagePipelineArtifactsBucketC6CC33E0",
+                          "PipelineArtifacts4A9B2621",
                           "Arn",
                         ],
                       },
@@ -832,7 +777,7 @@ exports[`Build Image Pipeline Snapshot 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "BuildImagePipelineArtifactsBucketEncryptionKey5E194B47",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -847,7 +792,7 @@ exports[`Build Image Pipeline Snapshot 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "BuildImagePipelineArtifactsBucketEncryptionKey5E194B47",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -863,6 +808,120 @@ exports[`Build Image Pipeline Snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "PipelineArtifactKeyEC0C0075": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "KeyPolicy": {
+          "Statement": [
+            {
+              "Action": "kms:*",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::111111111111:root",
+                    ],
+                  ],
+                },
+              },
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::KMS::Key",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "PipelineArtifacts4A9B2621": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "KMSMasterKeyID": {
+                  "Fn::GetAtt": [
+                    "PipelineArtifactKeyEC0C0075",
+                    "Arn",
+                  ],
+                },
+                "SSEAlgorithm": "aws:kms",
+              },
+            },
+          ],
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "ArtifactAccessLoggingD6FCABA3",
+          },
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "VersioningConfiguration": {
+          "Status": "Enabled",
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "PipelineArtifactsPolicy87787A0D": {
+      "Properties": {
+        "Bucket": {
+          "Ref": "PipelineArtifacts4A9B2621",
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*",
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "PipelineArtifacts4A9B2621",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "PipelineArtifacts4A9B2621",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
     },
     "WeeklySchedule60EC10E3": {
       "Properties": {

--- a/test/__snapshots__/demo-pipeline.test.ts.snap
+++ b/test/__snapshots__/demo-pipeline.test.ts.snap
@@ -219,7 +219,7 @@ exports[`Demo Pipeline Poky AMI Pipeline - check role name trim 1`] = `
         },
         "EncryptionKey": {
           "Fn::GetAtt": [
-            "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+            "PipelineArtifactKeyEC0C0075",
             "Arn",
           ],
         },
@@ -793,7 +793,7 @@ exports[`Demo Pipeline Poky AMI Pipeline - check role name trim 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucket90FE417D",
+                    "PipelineArtifacts4A9B2621",
                     "Arn",
                   ],
                 },
@@ -803,7 +803,7 @@ exports[`Demo Pipeline Poky AMI Pipeline - check role name trim 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "DemoPipelineArtifactsBucket90FE417D",
+                          "PipelineArtifacts4A9B2621",
                           "Arn",
                         ],
                       },
@@ -824,7 +824,7 @@ exports[`Demo Pipeline Poky AMI Pipeline - check role name trim 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -839,7 +839,7 @@ exports[`Demo Pipeline Poky AMI Pipeline - check role name trim 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -893,14 +893,14 @@ exports[`Demo Pipeline Poky AMI Pipeline - check role name trim 1`] = `
           "EncryptionKey": {
             "Id": {
               "Fn::GetAtt": [
-                "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                "PipelineArtifactKeyEC0C0075",
                 "Arn",
               ],
             },
             "Type": "KMS",
           },
           "Location": {
-            "Ref": "DemoPipelineArtifactsBucket90FE417D",
+            "Ref": "PipelineArtifacts4A9B2621",
           },
           "Type": "S3",
         },
@@ -1097,7 +1097,7 @@ exports[`Demo Pipeline Poky AMI Pipeline - check role name trim 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucket90FE417D",
+                    "PipelineArtifacts4A9B2621",
                     "Arn",
                   ],
                 },
@@ -1107,7 +1107,7 @@ exports[`Demo Pipeline Poky AMI Pipeline - check role name trim 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "DemoPipelineArtifactsBucket90FE417D",
+                          "PipelineArtifacts4A9B2621",
                           "Arn",
                         ],
                       },
@@ -1125,7 +1125,7 @@ exports[`Demo Pipeline Poky AMI Pipeline - check role name trim 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -1141,126 +1141,6 @@ exports[`Demo Pipeline Poky AMI Pipeline - check role name trim 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "DemoPipelineArtifactsBucket90FE417D": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "BucketEncryption": {
-          "ServerSideEncryptionConfiguration": [
-            {
-              "ServerSideEncryptionByDefault": {
-                "KMSMasterKeyID": {
-                  "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
-                    "Arn",
-                  ],
-                },
-                "SSEAlgorithm": "aws:kms",
-              },
-            },
-          ],
-        },
-        "PublicAccessBlockConfiguration": {
-          "BlockPublicAcls": true,
-          "BlockPublicPolicy": true,
-          "IgnorePublicAcls": true,
-          "RestrictPublicBuckets": true,
-        },
-      },
-      "Type": "AWS::S3::Bucket",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "DemoPipelineArtifactsBucketEncryptionKey6966F3E8": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "KeyPolicy": {
-          "Statement": [
-            {
-              "Action": "kms:*",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::12341234:root",
-                    ],
-                  ],
-                },
-              },
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::KMS::Key",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "DemoPipelineArtifactsBucketEncryptionKeyAlias732C5699": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "AliasName": "alias/codepipeline-pokyamipipeline2exportsoutputfngetattpipelinevpc0543904acidrblock70dec992demopipeline07a6b81c",
-        "TargetKeyId": {
-          "Fn::GetAtt": [
-            "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::KMS::Alias",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "DemoPipelineArtifactsBucketPolicy453CC1AA": {
-      "Properties": {
-        "Bucket": {
-          "Ref": "DemoPipelineArtifactsBucket90FE417D",
-        },
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "s3:*",
-              "Condition": {
-                "Bool": {
-                  "aws:SecureTransport": "false",
-                },
-              },
-              "Effect": "Deny",
-              "Principal": {
-                "AWS": "*",
-              },
-              "Resource": [
-                {
-                  "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucket90FE417D",
-                    "Arn",
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "DemoPipelineArtifactsBucket90FE417D",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::S3::BucketPolicy",
     },
     "DemoPipelineBuildDemoBuildCodePipelineActionRoleA72EE94C": {
       "Properties": {
@@ -1524,7 +1404,7 @@ exports[`Demo Pipeline Poky AMI Pipeline - check role name trim 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucket90FE417D",
+                    "PipelineArtifacts4A9B2621",
                     "Arn",
                   ],
                 },
@@ -1534,7 +1414,7 @@ exports[`Demo Pipeline Poky AMI Pipeline - check role name trim 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "DemoPipelineArtifactsBucket90FE417D",
+                          "PipelineArtifacts4A9B2621",
                           "Arn",
                         ],
                       },
@@ -1555,7 +1435,7 @@ exports[`Demo Pipeline Poky AMI Pipeline - check role name trim 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -1765,7 +1645,7 @@ exports[`Demo Pipeline Poky AMI Pipeline - check role name trim 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucket90FE417D",
+                    "PipelineArtifacts4A9B2621",
                     "Arn",
                   ],
                 },
@@ -1775,7 +1655,7 @@ exports[`Demo Pipeline Poky AMI Pipeline - check role name trim 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "DemoPipelineArtifactsBucket90FE417D",
+                          "PipelineArtifacts4A9B2621",
                           "Arn",
                         ],
                       },
@@ -1796,7 +1676,7 @@ exports[`Demo Pipeline Poky AMI Pipeline - check role name trim 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -2177,6 +2057,120 @@ def handler(event, context):
         ],
       },
       "Type": "AWS::Events::Rule",
+    },
+    "PipelineArtifactKeyEC0C0075": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "KeyPolicy": {
+          "Statement": [
+            {
+              "Action": "kms:*",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::12341234:root",
+                    ],
+                  ],
+                },
+              },
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::KMS::Key",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "PipelineArtifacts4A9B2621": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "KMSMasterKeyID": {
+                  "Fn::GetAtt": [
+                    "PipelineArtifactKeyEC0C0075",
+                    "Arn",
+                  ],
+                },
+                "SSEAlgorithm": "aws:kms",
+              },
+            },
+          ],
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "ArtifactAccessLoggingD6FCABA3",
+          },
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "VersioningConfiguration": {
+          "Status": "Enabled",
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "PipelineArtifactsPolicy87787A0D": {
+      "Properties": {
+        "Bucket": {
+          "Ref": "PipelineArtifacts4A9B2621",
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*",
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "PipelineArtifacts4A9B2621",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "PipelineArtifacts4A9B2621",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
     },
     "PipelineBuildLogs0533272F": {
       "DeletionPolicy": "Retain",
@@ -2606,7 +2600,7 @@ exports[`Demo Pipeline Snapshot Poky AMI Pipeline 1`] = `
         },
         "EncryptionKey": {
           "Fn::GetAtt": [
-            "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+            "PipelineArtifactKeyEC0C0075",
             "Arn",
           ],
         },
@@ -3180,7 +3174,7 @@ exports[`Demo Pipeline Snapshot Poky AMI Pipeline 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucket90FE417D",
+                    "PipelineArtifacts4A9B2621",
                     "Arn",
                   ],
                 },
@@ -3190,7 +3184,7 @@ exports[`Demo Pipeline Snapshot Poky AMI Pipeline 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "DemoPipelineArtifactsBucket90FE417D",
+                          "PipelineArtifacts4A9B2621",
                           "Arn",
                         ],
                       },
@@ -3211,7 +3205,7 @@ exports[`Demo Pipeline Snapshot Poky AMI Pipeline 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -3226,7 +3220,7 @@ exports[`Demo Pipeline Snapshot Poky AMI Pipeline 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -3280,14 +3274,14 @@ exports[`Demo Pipeline Snapshot Poky AMI Pipeline 1`] = `
           "EncryptionKey": {
             "Id": {
               "Fn::GetAtt": [
-                "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                "PipelineArtifactKeyEC0C0075",
                 "Arn",
               ],
             },
             "Type": "KMS",
           },
           "Location": {
-            "Ref": "DemoPipelineArtifactsBucket90FE417D",
+            "Ref": "PipelineArtifacts4A9B2621",
           },
           "Type": "S3",
         },
@@ -3484,7 +3478,7 @@ exports[`Demo Pipeline Snapshot Poky AMI Pipeline 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucket90FE417D",
+                    "PipelineArtifacts4A9B2621",
                     "Arn",
                   ],
                 },
@@ -3494,7 +3488,7 @@ exports[`Demo Pipeline Snapshot Poky AMI Pipeline 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "DemoPipelineArtifactsBucket90FE417D",
+                          "PipelineArtifacts4A9B2621",
                           "Arn",
                         ],
                       },
@@ -3512,7 +3506,7 @@ exports[`Demo Pipeline Snapshot Poky AMI Pipeline 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -3528,126 +3522,6 @@ exports[`Demo Pipeline Snapshot Poky AMI Pipeline 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "DemoPipelineArtifactsBucket90FE417D": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "BucketEncryption": {
-          "ServerSideEncryptionConfiguration": [
-            {
-              "ServerSideEncryptionByDefault": {
-                "KMSMasterKeyID": {
-                  "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
-                    "Arn",
-                  ],
-                },
-                "SSEAlgorithm": "aws:kms",
-              },
-            },
-          ],
-        },
-        "PublicAccessBlockConfiguration": {
-          "BlockPublicAcls": true,
-          "BlockPublicPolicy": true,
-          "IgnorePublicAcls": true,
-          "RestrictPublicBuckets": true,
-        },
-      },
-      "Type": "AWS::S3::Bucket",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "DemoPipelineArtifactsBucketEncryptionKey6966F3E8": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "KeyPolicy": {
-          "Statement": [
-            {
-              "Action": "kms:*",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::12341234:root",
-                    ],
-                  ],
-                },
-              },
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::KMS::Key",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "DemoPipelineArtifactsBucketEncryptionKeyAlias732C5699": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "AliasName": "alias/codepipeline-myteststackdemopipelinea8582e07",
-        "TargetKeyId": {
-          "Fn::GetAtt": [
-            "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::KMS::Alias",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "DemoPipelineArtifactsBucketPolicy453CC1AA": {
-      "Properties": {
-        "Bucket": {
-          "Ref": "DemoPipelineArtifactsBucket90FE417D",
-        },
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "s3:*",
-              "Condition": {
-                "Bool": {
-                  "aws:SecureTransport": "false",
-                },
-              },
-              "Effect": "Deny",
-              "Principal": {
-                "AWS": "*",
-              },
-              "Resource": [
-                {
-                  "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucket90FE417D",
-                    "Arn",
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "DemoPipelineArtifactsBucket90FE417D",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::S3::BucketPolicy",
     },
     "DemoPipelineBuildDemoBuildCodePipelineActionRoleA72EE94C": {
       "Properties": {
@@ -3911,7 +3785,7 @@ exports[`Demo Pipeline Snapshot Poky AMI Pipeline 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucket90FE417D",
+                    "PipelineArtifacts4A9B2621",
                     "Arn",
                   ],
                 },
@@ -3921,7 +3795,7 @@ exports[`Demo Pipeline Snapshot Poky AMI Pipeline 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "DemoPipelineArtifactsBucket90FE417D",
+                          "PipelineArtifacts4A9B2621",
                           "Arn",
                         ],
                       },
@@ -3942,7 +3816,7 @@ exports[`Demo Pipeline Snapshot Poky AMI Pipeline 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -4152,7 +4026,7 @@ exports[`Demo Pipeline Snapshot Poky AMI Pipeline 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucket90FE417D",
+                    "PipelineArtifacts4A9B2621",
                     "Arn",
                   ],
                 },
@@ -4162,7 +4036,7 @@ exports[`Demo Pipeline Snapshot Poky AMI Pipeline 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "DemoPipelineArtifactsBucket90FE417D",
+                          "PipelineArtifacts4A9B2621",
                           "Arn",
                         ],
                       },
@@ -4183,7 +4057,7 @@ exports[`Demo Pipeline Snapshot Poky AMI Pipeline 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -4565,6 +4439,120 @@ def handler(event, context):
       },
       "Type": "AWS::Events::Rule",
     },
+    "PipelineArtifactKeyEC0C0075": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "KeyPolicy": {
+          "Statement": [
+            {
+              "Action": "kms:*",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::12341234:root",
+                    ],
+                  ],
+                },
+              },
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::KMS::Key",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "PipelineArtifacts4A9B2621": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "KMSMasterKeyID": {
+                  "Fn::GetAtt": [
+                    "PipelineArtifactKeyEC0C0075",
+                    "Arn",
+                  ],
+                },
+                "SSEAlgorithm": "aws:kms",
+              },
+            },
+          ],
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "ArtifactAccessLoggingD6FCABA3",
+          },
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "VersioningConfiguration": {
+          "Status": "Enabled",
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "PipelineArtifactsPolicy87787A0D": {
+      "Properties": {
+        "Bucket": {
+          "Ref": "PipelineArtifacts4A9B2621",
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*",
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "PipelineArtifacts4A9B2621",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "PipelineArtifacts4A9B2621",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "PipelineBuildLogs0533272F": {
       "DeletionPolicy": "Retain",
       "Properties": {
@@ -4918,68 +4906,6 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "DemoArtifactB63FBDE0": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "LoggingConfiguration": {
-          "DestinationBucketName": {
-            "Ref": "ArtifactAccessLoggingD6FCABA3",
-          },
-        },
-        "VersioningConfiguration": {
-          "Status": "Enabled",
-        },
-      },
-      "Type": "AWS::S3::Bucket",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "DemoArtifactPolicy2E42C1C3": {
-      "Properties": {
-        "Bucket": {
-          "Ref": "DemoArtifactB63FBDE0",
-        },
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "s3:*",
-              "Condition": {
-                "Bool": {
-                  "aws:SecureTransport": "false",
-                },
-              },
-              "Effect": "Deny",
-              "Principal": {
-                "AWS": "*",
-              },
-              "Resource": [
-                {
-                  "Fn::GetAtt": [
-                    "DemoArtifactB63FBDE0",
-                    "Arn",
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "DemoArtifactB63FBDE0",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::S3::BucketPolicy",
-    },
     "DemoBuildProjectCA7F642A": {
       "DependsOn": [
         "DemoBuildProjectPolicyDocumentD1257A49",
@@ -4993,7 +4919,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
         },
         "EncryptionKey": {
           "Fn::GetAtt": [
-            "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+            "PipelineArtifactKeyEC0C0075",
             "Arn",
           ],
         },
@@ -5388,7 +5314,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucket90FE417D",
+                    "PipelineArtifacts4A9B2621",
                     "Arn",
                   ],
                 },
@@ -5398,7 +5324,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "DemoPipelineArtifactsBucket90FE417D",
+                          "PipelineArtifacts4A9B2621",
                           "Arn",
                         ],
                       },
@@ -5419,7 +5345,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -5434,7 +5360,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -5488,14 +5414,14 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
           "EncryptionKey": {
             "Id": {
               "Fn::GetAtt": [
-                "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                "PipelineArtifactKeyEC0C0075",
                 "Arn",
               ],
             },
             "Type": "KMS",
           },
           "Location": {
-            "Ref": "DemoPipelineArtifactsBucket90FE417D",
+            "Ref": "PipelineArtifacts4A9B2621",
           },
           "Type": "S3",
         },
@@ -5591,7 +5517,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
                 },
                 "Configuration": {
                   "BucketName": {
-                    "Ref": "DemoArtifactB63FBDE0",
+                    "Ref": "PipelineOutput78594CB5",
                   },
                   "Extract": "true",
                 },
@@ -5662,7 +5588,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "DemoArtifactB63FBDE0",
+                    "PipelineOutput78594CB5",
                     "Arn",
                   ],
                 },
@@ -5672,7 +5598,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "DemoArtifactB63FBDE0",
+                          "PipelineOutput78594CB5",
                           "Arn",
                         ],
                       },
@@ -5692,7 +5618,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucket90FE417D",
+                    "PipelineArtifacts4A9B2621",
                     "Arn",
                   ],
                 },
@@ -5702,7 +5628,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "DemoPipelineArtifactsBucket90FE417D",
+                          "PipelineArtifacts4A9B2621",
                           "Arn",
                         ],
                       },
@@ -5720,7 +5646,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -5736,126 +5662,6 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "DemoPipelineArtifactsBucket90FE417D": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "BucketEncryption": {
-          "ServerSideEncryptionConfiguration": [
-            {
-              "ServerSideEncryptionByDefault": {
-                "KMSMasterKeyID": {
-                  "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
-                    "Arn",
-                  ],
-                },
-                "SSEAlgorithm": "aws:kms",
-              },
-            },
-          ],
-        },
-        "PublicAccessBlockConfiguration": {
-          "BlockPublicAcls": true,
-          "BlockPublicPolicy": true,
-          "IgnorePublicAcls": true,
-          "RestrictPublicBuckets": true,
-        },
-      },
-      "Type": "AWS::S3::Bucket",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "DemoPipelineArtifactsBucketEncryptionKey6966F3E8": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "KeyPolicy": {
-          "Statement": [
-            {
-              "Action": "kms:*",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::12341234:root",
-                    ],
-                  ],
-                },
-              },
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::KMS::Key",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "DemoPipelineArtifactsBucketEncryptionKeyAlias732C5699": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "AliasName": "alias/codepipeline-myteststackdemopipelinea8582e07",
-        "TargetKeyId": {
-          "Fn::GetAtt": [
-            "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::KMS::Alias",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "DemoPipelineArtifactsBucketPolicy453CC1AA": {
-      "Properties": {
-        "Bucket": {
-          "Ref": "DemoPipelineArtifactsBucket90FE417D",
-        },
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "s3:*",
-              "Condition": {
-                "Bool": {
-                  "aws:SecureTransport": "false",
-                },
-              },
-              "Effect": "Deny",
-              "Principal": {
-                "AWS": "*",
-              },
-              "Resource": [
-                {
-                  "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucket90FE417D",
-                    "Arn",
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "DemoPipelineArtifactsBucket90FE417D",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::S3::BucketPolicy",
     },
     "DemoPipelineBuildDemoBuildCodePipelineActionRoleA72EE94C": {
       "Properties": {
@@ -6119,7 +5925,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucket90FE417D",
+                    "PipelineArtifacts4A9B2621",
                     "Arn",
                   ],
                 },
@@ -6129,7 +5935,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "DemoPipelineArtifactsBucket90FE417D",
+                          "PipelineArtifacts4A9B2621",
                           "Arn",
                         ],
                       },
@@ -6150,7 +5956,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -6360,7 +6166,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "DemoPipelineArtifactsBucket90FE417D",
+                    "PipelineArtifacts4A9B2621",
                     "Arn",
                   ],
                 },
@@ -6370,7 +6176,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "DemoPipelineArtifactsBucket90FE417D",
+                          "PipelineArtifacts4A9B2621",
                           "Arn",
                         ],
                       },
@@ -6391,7 +6197,7 @@ exports[`Demo Pipeline Snapshot Poky Pipeline 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "DemoPipelineArtifactsBucketEncryptionKey6966F3E8",
+                  "PipelineArtifactKeyEC0C0075",
                   "Arn",
                 ],
               },
@@ -6773,6 +6579,120 @@ def handler(event, context):
       },
       "Type": "AWS::Events::Rule",
     },
+    "PipelineArtifactKeyEC0C0075": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "KeyPolicy": {
+          "Statement": [
+            {
+              "Action": "kms:*",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::12341234:root",
+                    ],
+                  ],
+                },
+              },
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::KMS::Key",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "PipelineArtifacts4A9B2621": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "KMSMasterKeyID": {
+                  "Fn::GetAtt": [
+                    "PipelineArtifactKeyEC0C0075",
+                    "Arn",
+                  ],
+                },
+                "SSEAlgorithm": "aws:kms",
+              },
+            },
+          ],
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "ArtifactAccessLoggingD6FCABA3",
+          },
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "VersioningConfiguration": {
+          "Status": "Enabled",
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "PipelineArtifactsPolicy87787A0D": {
+      "Properties": {
+        "Bucket": {
+          "Ref": "PipelineArtifacts4A9B2621",
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*",
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "PipelineArtifacts4A9B2621",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "PipelineArtifacts4A9B2621",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "PipelineBuildLogs0533272F": {
       "DeletionPolicy": "Retain",
       "Properties": {
@@ -6780,6 +6700,68 @@ def handler(event, context):
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
+    },
+    "PipelineOutput78594CB5": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "ArtifactAccessLoggingD6FCABA3",
+          },
+        },
+        "VersioningConfiguration": {
+          "Status": "Enabled",
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "PipelineOutputPolicyCB4CC2E6": {
+      "Properties": {
+        "Bucket": {
+          "Ref": "PipelineOutput78594CB5",
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*",
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "PipelineOutput78594CB5",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "PipelineOutput78594CB5",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
     },
     "SourceRepoSourceRepositoryC86045A8": {
       "Properties": {

--- a/test/build-image-data-nag.test.ts
+++ b/test/build-image-data-nag.test.ts
@@ -42,17 +42,6 @@ describe('BuildImageDataStack cdk-nag AwsSolutions Pack', () => {
       ]
     );
 
-    NagSuppressions.addResourceSuppressionsByPath(
-      stack,
-      '/MyTestStack/BuildImageDataBucket/Resource',
-      [
-        {
-          id: 'AwsSolutions-S1',
-          reason: 'TODO: Add Access Logging',
-        },
-      ]
-    );
-
     // WHEN
     Aspects.of(stack).add(new AwsSolutionsChecks({ verbose: true }));
   });

--- a/test/build-image-pipeline-nag.test.ts
+++ b/test/build-image-pipeline-nag.test.ts
@@ -40,10 +40,6 @@ describe('BuildImagePipelineStack cdk-nag AwsSolutions Pack', () => {
         reason: 'TODO: Re-evaluate "*" per resources.',
       },
       {
-        id: 'AwsSolutions-S1',
-        reason: 'TODO: Re-evaluate bucket access logging.',
-      },
-      {
         id: 'AwsSolutions-KMS5',
         reason: 'TODO: Re-evaluate key rotation.',
       },

--- a/test/demo-pipeline-nag.test.ts
+++ b/test/demo-pipeline-nag.test.ts
@@ -48,10 +48,6 @@ describe('Demo pipeline cdk-nag AwsSolutions Pack', () => {
         id: 'AwsSolutions-KMS5',
         reason: 'TODO: Re-evaluate key rotation.',
       },
-      {
-        id: 'AwsSolutions-S1',
-        reason: 'TODO: Re-evaluate bucket access logging.',
-      },
     ]);
     // WHEN
     Aspects.of(stack).add(new AwsSolutionsChecks({ verbose: true }));


### PR DESCRIPTION
Set up a bucket for Pipeline Artifacts that uses access logging, the same KMS setup as the default, and uses our other required settings.