### PR TITLE
updated PipelineNetworkStack contructor to match other stacks & replaced deprecated attribute autoDeleteImages with emptyOnDelete

### DIFF
--- a/lib/build-image-repo.ts
+++ b/lib/build-image-repo.ts
@@ -16,7 +16,7 @@ export class BuildImageRepoStack extends cdk.Stack {
 
     this.repository = new ecr.Repository(this, 'BuildImageRepo', {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
-      autoDeleteImages: true,
+      emptyOnDelete: true,
     });
   }
 }

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -12,9 +12,8 @@ import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 export class PipelineNetworkStack extends cdk.Stack {
   /** The VPC for the pipeline to reside in. */
   public readonly vpc: ec2.IVpc;
-
-  constructor(scope: Construct, props?: cdk.StackProps) {
-    super(scope, 'PipelineNetwork', props);
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
 
     // We will create a VPC with 3 Private and Public subnets for AWS
     // Resources that have network interfaces (e.g. Connecting and EFS


### PR DESCRIPTION
- replaced emptyOnDelete by autoDeleteImages because of [WARNING] aws-cdk-lib.aws_ecr.RepositoryProps#autoDeleteImages is deprecated.
  Use `emptyOnDelete` instead.
  This API will be removed in the next major release.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
